### PR TITLE
Fixed GatherLite:p2pDatabase()

### DIFF
--- a/Scripts/methods.lua
+++ b/Scripts/methods.lua
@@ -915,7 +915,7 @@ end
 
 function GatherLite:p2pDatabase()
     GatherLite:CancelTimer(GatherLite.syncTimer)
-    if IsInGuild() and GatherLite.db.char.p2p.guild and GatherLite.syncedNodes.guild == 0 and GatherLite.tablelength(GatherLite.db.global.nodes) > 0 then
+    if IsInGuild() and GatherLite.db.char.p2p.guild and GatherLite.syncedNodes.guild == 0 and GatherLite:tablelength(GatherLite.db.global.nodes) > 0 then
         GatherLite:debug("Starting synchronization with guild")
         GatherLite.synchronizing = true;
         local totalNodes = GatherLite:copy(GatherLite.totalNodes);


### PR DESCRIPTION
Gatherlite.tablelength always returned 0, replacing the . with a : fixed that.