### PR TITLE
Removed SetBackdropColor causing problems in tbc classic pre patch

### DIFF
--- a/Scripts/methods.lua
+++ b/Scripts/methods.lua
@@ -437,7 +437,6 @@ function GatherLite:createWorldmapNode(node)
     f:SetSize(GatherLite.db.char.worldmap.size, GatherLite.db.char.worldmap.size)
     f.texture:SetTexture(object.icon)
     f.texture:SetSize(GatherLite.db.char.worldmap.size, GatherLite.db.char.worldmap.size)
-    f:SetBackdropColor(1, 0, 0, 1);
 
     f.node = node;
     f.object = object


### PR DESCRIPTION
Somehow SetBackdropColor doesn't exists anymore in tbc classic pre patch. This small change makes the addon useable again for now.