### PR TITLE
Got the following error when I've attempted to loot a titanium ore in…

### DIFF
--- a/scripts/methods.lua
+++ b/scripts/methods.lua
@@ -265,6 +265,9 @@ function GatherLite:UpdateNode(type, nodeID, mapID, posX, posY)
             if node.loot[exists].count == nil then
                 node.loot[exists].count = 0;
             end
+            if item.count == nil then
+                item.count = 0;
+            end
 
             node.loot[exists].count = node.loot[exists].count + item.count;
         end


### PR DESCRIPTION
Got the following error when I've attempted to loot a titanium ore node in Wintergrasp:
Gatherlite/scripts/methods.lua:274: attempt to perform arithmetic on field 'count' (a nil value)

I think this happens only when the previous node was saronite ore and vice versa.
Screenshot after I've added the following debug messages and attempted to loot a titanium node:
```
    for k, item in pairs(loot) do
        local exists = GatherLite:findLoot(node.loot, item.name);
        if not exists then
	    print("node.loot inserted, item.name=", item.name, " count=", count)
            table.insert(node.loot, {
                name = item.name,
                count = item.count,
                link = item.link
            })
        else
            if node.loot[exists].count == nil then
                print("node.loot index, exists=", exists)
                print("node.loot[exists].count before setting to 0 (should be nil):", node.loot[exists].count)
                node.loot[exists].count = 0;
                print("node.loot[exists].count after setting to 0 (should be 0):", node.loot[exists].count)
            end
            if item.count == nil then
                item.count = 0;
            end
            print("node.loot[exists].count after setting if == nil (should be 0 or greater):", node.loot[exists].count)
            print("item.count:", item.count)
            node.loot[exists].count = node.loot[exists].count + item.count;
        end
    end
```
![WoWScrnShot_032823_013252](https://user-images.githubusercontent.com/40395973/228096409-e23de466-1db8-4f5a-8f33-29ebea62368f.jpg)
